### PR TITLE
Fixed Previous & Next page link

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -272,9 +272,8 @@ function createPaginatedPages(
       context: {
         pagination: {
           page,
-          nextPagePath: index === 0 ? null : nextPagePath,
-          previousPagePath:
-            index === pages.length - 1 ? null : previousPagePath,
+          nextPagePath: index === pages.length - 1 ? null : nextPagePath,
+          previousPagePath: index === 0 ? null : previousPagePath,
           pageCount: pages.length,
           pathPrefix,
         },


### PR DESCRIPTION
Blog page was showing wrong link at bottom.. when you are on first page, it says "Previous" and when you click,it actually takes you to next page.  fixed that condition.